### PR TITLE
This PR adds the DQ_CoppeliaSimRobot abstract class

### DIFF
--- a/interfaces/coppeliasim/DQ_CoppeliaSimRobot.m
+++ b/interfaces/coppeliasim/DQ_CoppeliaSimRobot.m
@@ -40,14 +40,14 @@ classdef  (Abstract) DQ_CoppeliaSimRobot < handle
         get_configuration();
 
         % This method sets the target configuration velocities in the CoppeliaSim scene.
-        % It is required a dynamics disabled scene. 
+        % It requires a dynamics-enabled scene 
         set_target_configuration_velocities(); 
 
         % This method returns the configuration velocities in the CoppeliaSim scene.
         get_configuration_velocities();
 
         % This method sets the target configuration forces in the CoppeliaSim scene.
-        % It is required a dynamics disabled scene.
+        % It requires a dynamics-enabled scene.
         set_target_configuration_forces();
 
         % This method returns the configuration forces in the CoppeliaSim scene.

--- a/interfaces/coppeliasim/DQ_CoppeliaSimRobot.m
+++ b/interfaces/coppeliasim/DQ_CoppeliaSimRobot.m
@@ -1,0 +1,56 @@
+% (C) Copyright 2011-2025 DQ Robotics Developers
+% 
+% This file is part of DQ Robotics.
+% 
+%     DQ Robotics is free software: you can redistribute it and/or modify
+%     it under the terms of the GNU Lesser General Public License as published by
+%     the Free Software Foundation, either version 3 of the License, or
+%     (at your option) any later version.
+% 
+%     DQ Robotics is distributed in the hope that it will be useful,
+%     but WITHOUT ANY WARRANTY; without even the implied warranty of
+%     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%     GNU Lesser General Public License for more details.
+% 
+%     You should have received a copy of the GNU Lesser General Public License
+%     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+% 
+% DQ Robotics website: dqrobotics.github.io
+% 
+% Contributors:
+% 
+%    1. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
+%         - Responsible for the original implementation
+
+classdef  (Abstract) DQ_CoppeliaSimRobot < handle
+    properties (SetAccess = protected)
+        robot_name_;
+        coppeliasim_interface_;
+    end
+    methods(Abstract)
+        % This method sets the configuration in the CoppeliaSim scene.
+        % It is required a dynamics disabled scene. 
+        set_configuration(obj);
+
+        % This method sets the target configuration in the
+        % CoppeliaSim scene. It requires a dynamics-enabled scene
+        set_target_configuration(obj);
+
+        % This method returns the robot configuration in the CoppeliaSim scene.
+        get_configuration();
+
+        % This method sets the target configuration velocities in the CoppeliaSim scene.
+        % It is required a dynamics disabled scene. 
+        set_target_configuration_velocities(); 
+
+        % This method returns the configuration velocities in the CoppeliaSim scene.
+        get_configuration_velocities();
+
+        % This method sets the target configuration forces in the CoppeliaSim scene.
+        % It is required a dynamics disabled scene.
+        set_target_configuration_forces();
+
+        % This method returns the configuration forces in the CoppeliaSim scene.
+        get_configuration_forces();
+    end
+end

--- a/interfaces/coppeliasim/DQ_CoppeliaSimRobot.m
+++ b/interfaces/coppeliasim/DQ_CoppeliaSimRobot.m
@@ -28,29 +28,29 @@ classdef  (Abstract) DQ_CoppeliaSimRobot < handle
         coppeliasim_interface_;
     end
     methods(Abstract)
-        % This method sets the configuration in the CoppeliaSim scene.
+        % This method sets the robot configuration in the CoppeliaSim scene.
         % It is required a dynamics disabled scene. 
         set_configuration(obj);
 
-        % This method sets the target configuration in the
+        % This method sets the target robot configuration in the
         % CoppeliaSim scene. It requires a dynamics-enabled scene
         set_target_configuration(obj);
 
         % This method returns the robot configuration in the CoppeliaSim scene.
         get_configuration();
 
-        % This method sets the target configuration velocities in the CoppeliaSim scene.
+        % This method sets the target robot configuration velocities in the CoppeliaSim scene.
         % It requires a dynamics-enabled scene 
         set_target_configuration_velocities(); 
 
-        % This method returns the configuration velocities in the CoppeliaSim scene.
+        % This method returns the robot configuration velocities in the CoppeliaSim scene.
         get_configuration_velocities();
 
-        % This method sets the target configuration forces in the CoppeliaSim scene.
+        % This method sets the target robot configuration forces in the CoppeliaSim scene.
         % It requires a dynamics-enabled scene.
         set_target_configuration_forces();
 
-        % This method returns the configuration forces in the CoppeliaSim scene.
+        % This method returns the robot configuration forces in the CoppeliaSim scene.
         get_configuration_forces();
     end
 end


### PR DESCRIPTION
Hi @dqrobotics/developers,

The current ZMQ-based DQ Robotics interface with CoppeliaSim does not have yet robot classes. This PR takes a first step to address this, and proposes the abstract class `DQ_CoppeliaSimRobot`, which will enable the `DQ_CoppeliaSimRobotZMQ` class (to be proposed in a future PR).

<img src="https://github.com/user-attachments/assets/7cb43160-cde6-451d-9540-3e1978c4d723" alt="drawing" width="400"/>


Kind regards, 


Juancho